### PR TITLE
don't raise a KeyError on unknown command

### DIFF
--- a/src/cli/supercommand.cr
+++ b/src/cli/supercommand.cr
@@ -55,7 +55,7 @@ module Cli
 
       def __subcommand
         if command = __args.subcommand?
-          self.class.__subcommands[command]
+          self.class.__subcommands.fetch(command, nil)
         end
       end
     end


### PR DESCRIPTION
Currently, when you type an unknown subcommand (for example a typo), you hit a runtime error `missing hash key: "unknown_command" (KeyError)`. 
This change catches this and displays the help instead.