### PR TITLE
Bump crystal to 0.24.1

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -4,7 +4,7 @@ version: 0.6.10
 authors:
   - mosop
 
-crystal: 0.23.1
+crystal: 0.24.1
 
 dependencies:
   optarg:
@@ -16,8 +16,8 @@ dependencies:
 
 development_dependencies:
   have_files:
-    github: mosop/have_files
-    version: ~> 0.3.4
+    github: paulosuzart/have_files
+    branch: bump-crystal
   crystal_plus:
     github: mosop/crystal_plus
     version: ~> 0.1.4

--- a/spec/internal/explicit_exit_calls_standard_exit/run.cr
+++ b/spec/internal/explicit_exit_calls_standard_exit/run.cr
@@ -1,4 +1,4 @@
-require "../../src/cli"
+require "../../../src/cli"
 
 class Command < Cli::Command
   def run

--- a/spec/wiki/handling_events/run.cr
+++ b/spec/wiki/handling_events/run.cr
@@ -1,4 +1,4 @@
-require "../../src/cli"
+require "../../../src/cli"
 
 class FinallySmile < Cli::Command
   after_exit do |cmd, exit|

--- a/src/lib/ios/pipe.cr
+++ b/src/lib/ios/pipe.cr
@@ -1,13 +1,11 @@
 module Cli::Ios
-  class Pipe
+  class Pipe < IO
     # :nodoc:
     class Closed < Exception
       def initialize(io)
         super "Piped #{io} already closed."
       end
     end
-
-    include IO
 
     @reader : IO::FileDescriptor?
     @writer : IO::FileDescriptor?


### PR DESCRIPTION
This PR contains the small changes required to make it compatible with 0.24.1. 
**PLEASE BEAR THAT** the `shards.yml` points to a fork of `have_files`, so after also accepting the PR in that repo, this shards.yml need to be fixed to point to the right tag of that repo.
Hope you find it useful. 
regards